### PR TITLE
Update of our interface

### DIFF
--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -2,11 +2,13 @@
 
 namespace Cache\Doctrine;
 
+use Psr\Cache\CacheItemInterface;
+
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class CacheItem implements CacheItemInterface
+class CacheItem implements HasExpirationDateInterface, CacheItemInterface
 {
     /**
      * @var string
@@ -76,23 +78,7 @@ class CacheItem implements CacheItemInterface
             return true;
         }
 
-        return !$this->isExpired();
-    }
-
-    /**
-     * @return bool
-     */
-    public function isExpired()
-    {
-        if (!$this->hasValue) {
-            return true;
-        }
-
-        if ($this->expirationDate === null) {
-            return false;
-        }
-
-        return new \DateTime() > $this->expirationDate;
+        return ((new \DateTime()) <= $this->expirationDate);
     }
 
     /**

--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -51,7 +51,7 @@ class CacheItem implements HasExpirationDateInterface, CacheItemInterface
      */
     public function set($value)
     {
-        $this->value    = $value;
+        $this->value = $value;
         $this->hasValue = true;
 
         return $this;

--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -51,7 +51,7 @@ class CacheItem implements HasExpirationDateInterface, CacheItemInterface
      */
     public function set($value)
     {
-        $this->value = $value;
+        $this->value    = $value;
         $this->hasValue = true;
 
         return $this;

--- a/src/CachePool.php
+++ b/src/CachePool.php
@@ -123,7 +123,12 @@ class CachePool implements CacheItemPoolInterface
             );
         }
 
-        return $this->cache->save($item->getKey(), $item, $item->getExpirationDate()->getTimestamp() - time());
+        $timeToLive = 0;
+        if(null !== $expirationDate = $item->getExpirationDate()) {
+            $timeToLive = $expirationDate->getTimestamp() - time();
+        }
+
+        return $this->cache->save($item->getKey(), $item, $timeToLive);
     }
 
     /**

--- a/src/HasExpirationDateInterface.php
+++ b/src/HasExpirationDateInterface.php
@@ -9,6 +9,8 @@ namespace Cache\Doctrine;
 interface HasExpirationDateInterface
 {
     /**
+     * The date and time when the object expires.
+     *
      * @return \DateTime|null
      */
     public function getExpirationDate();

--- a/src/HasExpirationDateInterface.php
+++ b/src/HasExpirationDateInterface.php
@@ -6,13 +6,8 @@ namespace Cache\Doctrine;
  * @author Aaron Scherer <aequasi@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-interface CacheItemInterface extends \Psr\Cache\CacheItemInterface
+interface HasExpirationDateInterface
 {
-    /**
-     * @return bool
-     */
-    public function isExpired();
-
     /**
      * @return \DateTime|null
      */

--- a/tests/CacheItemTest.php
+++ b/tests/CacheItemTest.php
@@ -108,20 +108,4 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
         $item->expiresAfter(1);
         $this->assertEquals(new \DateTime('+1 second'), $item->getExpirationDate());
     }
-
-    public function testIsExpired()
-    {
-        $item = new CacheItem('test_key');
-
-        $this->assertTrue($item->isExpired());
-
-        $item->set('test');
-        $this->assertFalse($item->isExpired());
-
-        $item->expiresAt(new \DateTime('+5 seconds'));
-        $this->assertFalse($item->isExpired());
-
-        $item->expiresAt(new \DateTime('-50 seconds'));
-        $this->assertTrue($item->isExpired());
-    }
 }

--- a/tests/CacheItemTest.php
+++ b/tests/CacheItemTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cache\Doctrine\tests;
+namespace Cache\Doctrine\Tests;
 
 use Cache\Doctrine\CacheItem;
 use Psr\Cache\CacheItemInterface;
@@ -25,7 +25,7 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
     {
         $item = new CacheItem('test_key');
 
-        $ref = new \ReflectionObject($item);
+        $ref       = new \ReflectionObject($item);
         $valueProp = $ref->getProperty('value');
         $valueProp->setAccessible(true);
         $hasValueProp = $ref->getProperty('hasValue');
@@ -74,7 +74,7 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
 
         $date = new \DateTime();
 
-        $ref = new \ReflectionObject($item);
+        $ref  = new \ReflectionObject($item);
         $prop = $ref->getProperty('expirationDate');
         $prop->setAccessible(true);
         $prop->setValue($item, $date);

--- a/tests/CacheItemTest.php
+++ b/tests/CacheItemTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cache\Doctrine\Tests;
+namespace Cache\Doctrine\tests;
 
 use Cache\Doctrine\CacheItem;
 use Psr\Cache\CacheItemInterface;
@@ -25,7 +25,7 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
     {
         $item = new CacheItem('test_key');
 
-        $ref       = new \ReflectionObject($item);
+        $ref = new \ReflectionObject($item);
         $valueProp = $ref->getProperty('value');
         $valueProp->setAccessible(true);
         $hasValueProp = $ref->getProperty('hasValue');
@@ -72,10 +72,9 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($item->getExpirationDate());
 
-
         $date = new \DateTime();
 
-        $ref  = new \ReflectionObject($item);
+        $ref = new \ReflectionObject($item);
         $prop = $ref->getProperty('expirationDate');
         $prop->setAccessible(true);
         $prop->setValue($item, $date);


### PR DESCRIPTION
Sorry for doing such a big rewrite. 

I removed the `CacheItem::isExpired` function because `!(CacheItem::isExpired) === CacheItem::isHit`. Which feels redundant. 

I removed the interface inheritance because it is no reason to have it. This way it could be reused by others. I would aslo suggest to move this interface to a separate package according to the _common reuse principle_.
