### PR TITLE
Make sure we return false when committing.

### DIFF
--- a/tests/CachePoolTest.php
+++ b/tests/CachePoolTest.php
@@ -223,7 +223,7 @@ class CachePoolTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($prop->getValue($this->pool));
 
         $this->assertFalse($this->pool->commit());
-        $this->assertNotEmpty($prop->getValue($this->pool));
+        $this->assertEmpty($prop->getValue($this->pool));
     }
 
     public function testCommitMultipleItems()
@@ -244,6 +244,6 @@ class CachePoolTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($prop->getValue($this->pool));
 
         $this->assertFalse($this->pool->commit());
-        $this->assertNotEmpty($prop->getValue($this->pool));
+        $this->assertEmpty($prop->getValue($this->pool));
     }
 }


### PR DESCRIPTION
This adds a tests to make sure we do not implement commit like this: 

``` php

public function commit()
    {
        $saved = true;
        foreach ($this->deferred as $item) {
            $saved = !$this->save($item));
        }
        $this->deferred = [];

        return $saved;
    }

```
